### PR TITLE
TPC toolkit now checks python version

### DIFF
--- a/swarm64_run_tpc_benchmark
+++ b/swarm64_run_tpc_benchmark
@@ -14,6 +14,11 @@ fileConfig('configs/logging.ini')
 logger = logging.getLogger()
 
 if __name__ == '__main__':
+    py_version_info = sys.version_info
+    if py_version_info < (3, 6):
+        logger.error('Your python version does not match the requirements.')
+        sys.exit()
+
     args_to_parse = argparse.ArgumentParser(argument_default=argparse.SUPPRESS)
 
     args_to_parse.add_argument('--dsn', required=True, help=(

--- a/swarm64_tpc_toolkit/streams.py
+++ b/swarm64_tpc_toolkit/streams.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 
 import logging
 import os


### PR DESCRIPTION
Check the python version (min. 3.6) to avoid tickets due to a wrong interpreter.