### PR TITLE
Round to 10+2 digits max

### DIFF
--- a/swarm64_tpc_toolkit/correctness.py
+++ b/swarm64_tpc_toolkit/correctness.py
@@ -1,3 +1,4 @@
+
 import logging
 import os
 
@@ -24,6 +25,10 @@ class Correctness:
         return filepath
 
     @classmethod
+    def round_to_precision(cls, value):
+        return '%.12g' % float('%.2f' % value)
+
+    @classmethod
     def check_for_mismatches(cls, truth, result):
         merge = truth.merge(result, indicator=True, how='left')
         differences = merge.loc[lambda x: x['_merge'] != 'both']
@@ -42,7 +47,9 @@ class Correctness:
                     elif np.isinf(truth_datum):
                         matches = (np.isinf(result_datum) == True)
                     else:
-                        matches = np.isclose(truth_datum, result_datum, rtol=1e-12, atol=0)
+                        matches = (
+                            cls.round_to_precision(truth_datum) == cls.round_to_precision(result_datum))
+
                 elif truth.dtypes[column_name] == 'object':
                     matches = (str(truth_datum) == str(result_datum))
                 else:

--- a/tests/test_correctness_acceptance.py
+++ b/tests/test_correctness_acceptance.py
@@ -128,7 +128,7 @@ def test_correctness_full_equal_column_swapped(correctness):
 def test_correctness_precision(correctness):
     CSV_PRECISION_A = '''id,value
     1,9999999999.1349
-    2,9999999999.1349'''
+    2,9999999999.1399'''
     truth = get_dataframe(CSV_PRECISION_A)
 
     CSV_PRECISION_B = '''id,value
@@ -138,6 +138,14 @@ def test_correctness_precision(correctness):
 
     mismatch_idx = correctness._check_correctness_impl(truth, result)
     assert mismatch_idx == [0]
+
+
+def test_tpch_precision(correctness):
+    truth = pandas.DataFrame([[0.05000012926042882], [0.04999679231408742]])
+    result = pandas.DataFrame([[0.0499967923141588], [0.0500001292604431]])
+
+    mismatch_idx = correctness._check_correctness_impl(truth, result)
+    assert mismatch_idx == []
 
 
 def test_correctness_full_equal_within_precision(correctness):


### PR DESCRIPTION
Ok, apparently this is the best way to do the TPC-H required rounding (-9,999,999,999.99  to +9,999,999,999.99) in Python. Luc was right™️. But, I think we now also have a good implementation with test coverage.